### PR TITLE
Bump aiohttp to 3.14.1 to fix Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ discord.py==2.7.1
 APScheduler==3.11.2
 icalendar==7.1.2
 requests==2.34.2
-aiohttp==3.14.0
+aiohttp==3.14.1
 feedparser==6.0.12
 pytz==2026.2
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Bumps `aiohttp` from 3.14.0 to 3.14.1, resolving all 8 open Dependabot alerts (all `aiohttp <= 3.14.0`):

- HTTP/1 pipelined requests queue without limit (medium)
- C HTTP parser bypasses `max_line_size` for fragmented lines (medium)
- TLS server hostname override ignored when reusing HTTPS connections (low)
- Incomplete websocket frame payloads bypass memory limits (medium)
- DigestAuthMiddleware applies credentials to cross-origin redirect challenges (medium)
- Payload response resources not closed after mid-body disconnect (low)
- Host-only cookies become domain cookies after CookieJar persistence (low)
- Unread compressed request bodies bypass `client_max_size` during cleanup (medium)

Stays within discord.py's `aiohttp>=3.7.4,<4` constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)